### PR TITLE
Fixed error in calculation of pixel spacing of the z axis: Because Im…

### DIFF
--- a/src/ImagineFormat.jl
+++ b/src/ImagineFormat.jl
@@ -62,7 +62,7 @@ function load(io::Stream{format"Imagine"}; mode="r")
     pstart = h["piezo"]["stop position"]
     pstop = h["piezo"]["start position"]
     if length(sz)>2
-        dz = abs(pstart - pstop)/sz[3]
+        dz = abs(pstart - pstop)/(sz[3]-1)
     else dz = 0.0 end
 
     axisnames = havez ? (:x, :l, :z) : (:x, :l)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ img = load("test.imagine")
 @test timedim(img) == 4
 @test axisnames(img) == (:x, :l, :z, :time)
 @test pixelspacing(img)[1:2] == (0.71μm, 0.71μm)
-@test pixelspacing(img)[3] ≈ (2/3)*100μm
+@test pixelspacing(img)[3] ≈ 100μm
 
 bn = joinpath(tempdir(), randstring())
 ifn = string(bn, ".imagine")


### PR DESCRIPTION
…agine samples at the endpoints of the piezo range (on-grid rather than on-cell) the number of intervals is one less than the number of frames per stack