### PR TITLE
Remove REQUIRE and add Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,24 @@
+name = "ImagineFormat"
+uuid = "4bab44a2-5ff2-5a6b-8e10-825fb9ac126a"
+version = "1.0.1"
+
+[deps]
+AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
+ImageMetadata = "bc367c6b-8a6b-528e-b4bd-a4b897500b49"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SharedArrays = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[compat]
+FixedPointNumbers = ">=0.3.0"
+ImageMetadata = ">=0.1.1"
+Images = ">=0.6.0"
+
+[extras]
+Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Images", "Test"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,0 @@
-julia 0.7
-AxisArrays
-ImageMetadata 0.1.1
-FixedPointNumbers 0.3.0
-FileIO
-Unitful


### PR DESCRIPTION
This is kind of a trivial PR, but I don't see a good way to fit ImagineFormat into a Julia 0.7/1.0 dependency tree without it.