### PR TITLE
Update bounds on Unitful

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,4 +3,4 @@ AxisArrays
 ImageMetadata 0.1.1
 FixedPointNumbers 0.3.0
 FileIO
-Unitful
+Unitful 0.12


### PR DESCRIPTION
This should technically require a lower bound of 0.12 on Unitful, so the best way to handle #27 is probably just to make a new release.