### PR TITLE
Allow stimulus-related metadata

### DIFF
--- a/src/ImagineFormat.jl
+++ b/src/ImagineFormat.jl
@@ -222,7 +222,12 @@ const field_key_dict = Dict{AbstractString,Function}(
     "angle from horizontal (deg)"  => float64_or_empty,
     "x translation in pixels"      => x->parse(Int,x) != 0,
     "y translation in pixels"      => x->parse(Int,x) != 0,
-    "rotation angle in degree"     => x->parse(Float64,x) != 0)
+    "rotation angle in degree"     => x->parse(Float64,x) != 0,
+    "stimulus scan hi"             => parse_vector_int,
+    "stimulus scan lo"             => parse_vector_int,
+    "stimulus frame hi"            => parse_vector_int,
+    "stimulus frame lo"            => parse_vector_int,
+    "stimulus sequence"            => identity)
 
 
 function parse_header(s::IOStream)

--- a/src/ImagineFormat.jl
+++ b/src/ImagineFormat.jl
@@ -436,6 +436,7 @@ writeMHz(io,x) = nothing
 
 const write_dict = Dict{String,Function}(
     "bidirectional"                => (io,x)->x ? print(io, 1) : print(io, 0),
+    "bidirection"                  => (io,x)->x ? print(io, 1) : print(io, 0),
     "start position"               => writeum,
     "stop position"                => writeum,
     "vertical shift speed"         => (io,x)->(writeus(io,x); print(io,'\n')),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,10 +40,12 @@ MHz = u"MHz"
 
 h = ImagineFormat.parse_header("test_noshift.imagine")
 h["byte order"] = ENDIAN_BOM == 0x04030201 ? "l" : "b"
-ImagineFormat.save_header(ifn, h)
+h["extra stuff"] = "Tuesday"
+ImagineFormat.save_header(ifn, h; misc=("extra stuff",))
 h2 = ImagineFormat.parse_header(ifn)
 @test isnan(h["readout rate"]) && isnan(h2["readout rate"])
 @test isnan(h["vertical shift speed"]) && isnan(h2["vertical shift speed"])
+@test h2["extra stuff"] == "Tuesday"
 rm(ifn)
 img2 = 0
 GC.gc(); GC.gc(); GC.gc()
@@ -83,6 +85,7 @@ img = load("no_z.imagine")
 @test pixelspacing(img) == (-1μm, -1μm)
 
 # Fix deprecations in loading imagine-cam file incompatibility
+@info "Two warnings are expected"
 img = load("test_nocam.imagine")
 @test isempty(img)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,12 +40,12 @@ MHz = u"MHz"
 
 h = ImagineFormat.parse_header("test_noshift.imagine")
 h["byte order"] = ENDIAN_BOM == 0x04030201 ? "l" : "b"
-h["extra stuff"] = "Tuesday"
-ImagineFormat.save_header(ifn, h; misc=("extra stuff",))
+h["stimulus scan hi"] = [3, 5]
+ImagineFormat.save_header(ifn, h; misc=("stimulus scan hi",))
 h2 = ImagineFormat.parse_header(ifn)
 @test isnan(h["readout rate"]) && isnan(h2["readout rate"])
 @test isnan(h["vertical shift speed"]) && isnan(h2["vertical shift speed"])
-@test h2["extra stuff"] == "Tuesday"
+@test h2["stimulus scan hi"] == [3, 5]
 rm(ifn)
 img2 = 0
 GC.gc(); GC.gc(); GC.gc()


### PR DESCRIPTION
This adds basic support for stimulus sequences encoded in the header file. The three new optional fields are:
- `"stimulus sequence"`: a delimiter-separated string listing your stimulus names in the order in which they are delivered. Example: `"chemical1$chemical2$chemical1"`
- `"stimulus pulses"`: a `Vector{Int}` containing the scan numbers in the `.ai` file at which stimulus pulses occur
- `"stimulus frame"`: a `Vector{Int}` encoding the next frame index after each stimulus pulse
 